### PR TITLE
Working Platane/snk generation for README.md

### DIFF
--- a/.github/workflows/Snake.yml
+++ b/.github/workflows/Snake.yml
@@ -2,13 +2,13 @@
 
 name: Generate Snake
 
-# Controls when the action will run. Every 6 hours.
 on:
+  # Controls when the action will run. Every 6 hours.
   schedule:
       # every 6 hours
     - cron: "0 */6 * * *"
 
-# Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -19,33 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-     
+    steps:     
       - uses: Platane/snk@master
         id: snake-gif
         with:
           github_user_name: mishmanners
           gif_out_path: dist/github-contribution-grid-snake.gif
-          svg_out_path: dist/github-contribution-grid-snake.svg
-          
-      # add and commit the changes. Commenting out as this is not working    
-      # - run:
-      #    git config --global mishmanners
-      #    git add dist
-      #    git commit -m 'add file'
-     
-     # show the status of the build
-      - run: git status
-          
-      # Push the changes to Main branch
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: master
-          force: true
+          svg_out_path: dist/github-contribution-grid-snake.svg          
           
       - uses: crazy-max/ghaction-github-pages@v2.1.3
         with:

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ As for the charts 🥧, if you like my A+ stats, then you can make your own by c
 
 <!-- [![trophy](https://github-profile-trophy.vercel.app/?username=mishmanners&theme=radical)](https://github.com/ryo-ma/github-profile-trophy) ONLY if I want to show the trophy things here -->
 
+<!-- platane/snk works, it just puts it on a new branch -->
+![mishmanners snake gif](https://github.com/mishmanners/MishManners/blob/output/github-contribution-grid-snake.gif)


### PR DESCRIPTION
When we were debugging, I lead you down the wrong path. Nothing gets committed, instead, the image gets shipped to a new branch called `output`. This is clever, because it doesn't clutter your default branch with a ton of commits. It also does not add this push to your contribution graph since it is on a different branch.  