### PR TITLE
Update Snake.yml

### DIFF
--- a/.github/workflows/Snake.yml
+++ b/.github/workflows/Snake.yml
@@ -1,6 +1,8 @@
 # GitHub Action for generating a contribution graph with a snake eating your contributions.
 
 name: Generate Snake
+permissions: 
+  contents: write
 
 # Controls when the action will run. This action runs every 6 hours.
 


### PR DESCRIPTION
Hello dear Mishmanners. While I was trying to add snake to my GitHub profile, I did every thing right, but I Was running into git exits with 128 in my action on deploy page. Apparently through some recent updates I figured that out The default GITHUB_TOKEN secret for the action doesn't appear to have the permission to write by default to the contents of the repository. Adding the following to the top of the action below name: fixed it for me.

this is my first contribution, so I was so excited to be part of the open source community as soon as I found out 